### PR TITLE
Merge dev into master

### DIFF
--- a/Spotify.ahk
+++ b/Spotify.ahk
@@ -7,43 +7,22 @@ class Spotify {
 		this.Albums := new Albums(this)
 		this.Artists := new Artists(this)
 	}
-	class SimpleArtistObject {
-		__New(response) {
-			RegexMatch(response, "https:\/\/o.*?""", ExternalURL)
-			this.ExternalURL := SubStr(ExternalURL, 1, (StrLen(ExternalURL) - 1))
-			RegexMatch(response, "me"" : "".*?"",\n", Name)
-			this.Name := SubStr(Name, 8, (StrLen(Name) - 10))
-			RegexMatch(this.ExternalURL, "[0-9a-zA-Z]{22}", ID)
-			this.ID := ID
-		}
-	}
-	class FullArtistObject {
-		__New(response) {
-			RegexMatch(response, "https:\/\/o.*?""", ExternalURL)
-			this.ExternalURL := SubStr(ExternalURL, 1, (StrLen(ExternalURL) - 1))
-			RegexMatch(response, "me"" : "".*?"",\n", Name)
-			this.Name := SubStr(Name, 8, (StrLen(Name) - 10))
-			RegexMatch(this.ExternalURL, "[0-9a-zA-Z]{22}", ID)
-			this.ID := ID
-			RegexMatch(response, """total"" : [0-9]*", Followers)
-			this.Followers := SubStr(Followers, 10)
-			RegexMatch(response, "s"" : \[.*? ]", Genres)
-			this.Genres := StrSplit(SubStr(Genres, 7) , ",", "[ ""]")
-		}
-	}
 }
 class Util {
 	__New(ParentObject) {
-		this.ParentObject:=ParentObject
-		this.RefreshLoc:="HKCU\Software\SpotifyAHK"
+		this.ParentObject := ParentObject
+		MsgBox, % "New util created"
+		this.RefreshLoc := "HKCU\Software\SpotifyAHK"
 		this.StartUp()
 	}
 	StartUp() {
-		RegRead, refresh,% this.RefreshLoc, refreshToken
+		RegRead, refresh, % this.RefreshLoc, refreshToken
+		MsgBox, % "StartUp called with refresh enc token of:`n" . refresh
 		if (refresh) {
-			this.RefreshAuth(refresh)
+			this.RefreshTempToken(refresh)
 		}
 		else {
+			MsgBox, % "Doing web auth"
 			this.auth := ""
 			paths := {}
 			paths["/callback"] := this["authCallback"].bind(this)
@@ -52,12 +31,14 @@ class Util {
 			server.SetPaths(paths)
 			server.Serve(8000)
 			Run, % "https://accounts.spotify.com/en/authorize?client_id=9fe26296bb7b4330ac59339efd2742b0&response_type=code&redirect_uri=http:%2F%2Flocalhost:8000%2Fcallback&scope=user-modify-playback-state%20user-read-currently-playing%20user-read-playback-state%20user-library-modify%20user-library-read%20user-read-email%20user-read-private%20user-read-birthdate%20user-follow-read%20user-follow-modify%20playlist-read-private%20playlist-read-collaborative%20playlist-modify-public%20playlist-modify-private%20user-read-recently-played%20user-top-read"
+			MsgBox, % "Waiting for web auth"
 			loop {
 				Sleep, -1
-			} until (this.InternalIsReady() = true)
-			this.GetTokens()
+			} until (this.WebAuthDone() = true)
+			this.FetchTokens()
 		}
 	}
+	; TIMEOUT CHECKER/SETTER
 	SetTimeout() {
 		TimeOut := A_Now
 		EnvAdd, TimeOut, 1, hours
@@ -70,22 +51,27 @@ class Util {
 		this.TimeLastChecked := A_Min
 		if (A_Now > this.TimeOut) {
 			RegRead, refresh, % this.RefreshLoc, refreshToken
-			this.RefreshAuth(refresh)
+			this.RefreshTempToken(refresh)
 		}
 	}
-	RefreshAuth(refresh) {
+	; AUTHORIZATION FUNCTIONS
+	RefreshTempToken(refresh) {
+		MsgBox, % "Refreshing temp token with enc refresh:`n" . refresh
 		refresh := this.DecryptToken(refresh)
+		MsgBox, % "Refreshing temp token with dec refresh:`n" . refresh
 		arg := {1:{1:"Content-Type", 2:"application/x-www-form-urlencoded"}, 2:{1:"Authorization", 2:"Basic OWZlMjYyOTZiYjdiNDMzMGFjNTkzMzllZmQyNzQyYjA6ZWNhNjU2ZDFkNTczNDNhOTllMWJjNWVmODQ0YmY2NGM="}}
-		response := this.CustomCall("POST", "https://accounts.spotify.com/api/token?grant_type=refresh_token&refresh_token=" . refresh, arg)
+		response := this.CustomCall("POST", "https://accounts.spotify.com/api/token?grant_type=refresh_token&refresh_token=" . refresh, arg, true)
+		MsgBox, % "Spoofy responds to refresh with:`n"
 		this.authState := true
 		if (InStr(response, "refresh_token")) {
-			this.SaveRefresh(response)
+			this.SaveRefreshToken(response)
 		}
 		RegexMatch(response, "s_token"":"".*?""", token)
 		this.token := this.TrimToken(token)
 		this.SetTimeout()
 	}
-	GetTokens() {
+	FetchTokens() {
+		MsgBox, % "FetchTokens called"
 		if (this.fail) {
 			ErrorLevel := 1
 			return
@@ -96,42 +82,29 @@ class Util {
 		AHKsock_Close(-1)
 		arg := {1:{1:"Content-Type", 2:"application/x-www-form-urlencoded"}, 2:{1:"Authorization", 2:"Basic OWZlMjYyOTZiYjdiNDMzMGFjNTkzMzllZmQyNzQyYjA6ZWNhNjU2ZDFkNTczNDNhOTllMWJjNWVmODQ0YmY2NGM="}}
 		response := this.CustomCall("POST", "https://accounts.spotify.com/api/token?grant_type=authorization_code&code=" . this.auth . "&redirect_uri=http:%2F%2Flocalhost:8000%2Fcallback", arg)
+		MsgBox, % "Spoofy responds with:`n" . response
 		RegexMatch(response, "s_token"":"".*?""", token)
 		this.token := this.TrimToken(token)
-		this.SaveRefresh(response)
+		this.SaveRefreshToken(response)
 	}
-	SaveRefresh(response) {
+	; MISC TOKEN FUNCTIONS
+	SaveRefreshToken(response) {
 		RegexMatch(response, "h_token"":"".*?""", response)
 		if !(response) {
 			return
 		}
-		response:=this.encryptToken(this.TrimToken(response))
+		response := this.encryptToken(this.TrimToken(response))
 		RegWrite, REG_SZ, % this.RefreshLoc, RefreshToken, % response
 		return
 	}
 	TrimToken(token) {
-		StringTrimLeft, token, token, 10
-		StringTrimRight, token, token, 1
-		return token
+		return (SubStr(token, 11, (StrLen(token) - 12)))
 	}
-	IsReady() {
-		if (this.token != "") {
-			return true
-		}
-		else {
-			return false
-		}
-	}
-	InternalIsReady() {
-		if (this.auth != "") {
-			return true
-		}
-		else {
-			return false
-		}
-	}
-	CustomCall(method, url, HeaderArray := "") {
-		this.CheckTimeout()
+	; API CALL FUNCTION WITH AUTO-AUTH/HEADERS
+	CustomCall(method, url, HeaderArray := "", noTimeOut) {
+		if !(noTimeOut) {
+			this.CheckTimeout()
+
 		if !((InStr(url, "https://api.spotify.com")) || (InStr(url, "https://accounts.spotify.com/api/"))) {
 			url := "https://api.spotify.com/v1/" . url
 		}
@@ -146,6 +119,7 @@ class Util {
 		SpotifyWinHttp.Send()
 		return SpotifyWinHttp.ResponseText
 	}
+	; WEB AUTH FUNCTIONS
 	NotFound(ByRef req, ByRef res) {
 		res.SetBodyText("Page not found")
 	}
@@ -155,16 +129,20 @@ class Util {
 		this.auth := req.queries["code"]
 		this.fail := req.queries["error"]
 	}
-	EncryptToken(RefreshToken){
+	WebAuthDone() {
+		return (this.auth ? true : false)
+	}
+	; TOKEN ENCRYPTION
+	EncryptToken(RefreshToken) {
 		return crypt.encrypt.strEncrypt(RefreshToken, this.GetIDs(), 5, 3)
 	}
-	DecryptToken(RefreshToken){
-		try{
+	DecryptToken(RefreshToken) {
+		try {
 			return crypt.encrypt.strDecrypt(RefreshToken, this.GetIDs(), 5, 3)
 		} catch {
-			regDelete, % this.RefreshLoc, RefreshToken
-			this.startup()
-			regRead, RefreshToken, % this.RefreshLoc, refreshToken
+			RegDelete, % this.RefreshLoc, RefreshToken
+			this.StartUp()
+			RegRead, RefreshToken, % this.RefreshLoc, refreshToken
 			return crypt.encrypt.strDecrypt(RefreshToken, this.GetIDs(), 5, 3)
 		}
 	}
@@ -179,6 +157,7 @@ class Util {
 		}
 		return id
 	}
+	
 }
 class Player {
 	__New(ParentObject) {
@@ -197,7 +176,7 @@ class Player {
 		return this.ParentObject.Util.CustomCall("GET", "me/player/recently-played")
 	}
 	PausePlayback() {
-		return this.ParentObject.Util.CustomCall("PUT", "me/player/pause")
+		return this.ParentObject.Util.CustomCall("POST", "me/player/pause")
 	}
 	SeekTime(TimeInMS) {
 		return this.ParentObject.Util.CustomCall("PUT", "me/player/seek?position_ms=" . TimeInMS)
@@ -269,7 +248,7 @@ class Artists {
 		this.ParentObject := ParentObject
 	}
 	GetArtist(ArtistID) {
-		return new this.ParentObject.FullArtistObject(this.ParentObject.Util.CustomCall("GET", "artists/" . ArtistID))
+		return this.ParentObject.Util.CustomCall("GET", "artists/" . ArtistID)
 	}
 	GetArtistAlbums(ArtistID) {
 		return this.ParentObject.Util.CustomCall("GET", "artists/" . ArtistID . "/albums")
@@ -279,6 +258,17 @@ class Artists {
 	}
 	GetArtistTopTracks(ArtistID) {
 		return this.ParentObject.Util.CustomCall("GET", "artists/" . ArtistID . "/top-tracks")
+	}
+}
+class Tracks {
+	__New(ParentObject) {
+		this.ParentObject := ParentObject
+	}
+	GetAudioFeatures(TrackID) {
+		return this.ParentObject.Util.CustomCall("GET", "audio-features/" . TrackID)
+	}
+	GetTrack(TrackID) {
+		return this.ParentObject.Util.CustomCall("GET", "tracks/" . TrackID)
 	}
 }
 #Include <AHKsock>

--- a/Spotify.ahk
+++ b/Spotify.ahk
@@ -11,18 +11,15 @@ class Spotify {
 class Util {
 	__New(ParentObject) {
 		this.ParentObject := ParentObject
-		MsgBox, % "New util created"
 		this.RefreshLoc := "HKCU\Software\SpotifyAHK"
 		this.StartUp()
 	}
 	StartUp() {
 		RegRead, refresh, % this.RefreshLoc, refreshToken
-		MsgBox, % "StartUp called with refresh enc token of:`n" . refresh
 		if (refresh) {
 			this.RefreshTempToken(refresh)
 		}
 		else {
-			MsgBox, % "Doing web auth"
 			this.auth := ""
 			paths := {}
 			paths["/callback"] := this["authCallback"].bind(this)
@@ -31,7 +28,6 @@ class Util {
 			server.SetPaths(paths)
 			server.Serve(8000)
 			Run, % "https://accounts.spotify.com/en/authorize?client_id=9fe26296bb7b4330ac59339efd2742b0&response_type=code&redirect_uri=http:%2F%2Flocalhost:8000%2Fcallback&scope=user-modify-playback-state%20user-read-currently-playing%20user-read-playback-state%20user-library-modify%20user-library-read%20user-read-email%20user-read-private%20user-read-birthdate%20user-follow-read%20user-follow-modify%20playlist-read-private%20playlist-read-collaborative%20playlist-modify-public%20playlist-modify-private%20user-read-recently-played%20user-top-read"
-			MsgBox, % "Waiting for web auth"
 			loop {
 				Sleep, -1
 			} until (this.WebAuthDone() = true)
@@ -44,24 +40,19 @@ class Util {
 		this.TimeOut := TimeOut
 	}
 	CheckTimeout() {
-		MsgBox, % "CheckTimeout called"
 		if (this.TimeLastChecked = A_Min) {
 			return
 		}
 		this.TimeLastChecked := A_Min
 		if (A_Now > this.TimeOut) {
 			RegRead, refresh, % this.RefreshLoc, refreshToken
-			MsgBox, % "Timeout confirmed"
 			this.RefreshTempToken(refresh)
 		}
 	}
 	RefreshTempToken(refresh) {
-		MsgBox, % "Refreshing temp token with enc refresh:`n" . refresh
 		refresh := this.DecryptToken(refresh)
-		MsgBox, % "Refreshing temp token with dec refresh:`n" . refresh
 		arg := {1:{1:"Content-Type", 2:"application/x-www-form-urlencoded"}, 2:{1:"Authorization", 2:"Basic OWZlMjYyOTZiYjdiNDMzMGFjNTkzMzllZmQyNzQyYjA6ZWNhNjU2ZDFkNTczNDNhOTllMWJjNWVmODQ0YmY2NGM="}}
 		response := this.CustomCall("POST", "https://accounts.spotify.com/api/token?grant_type=refresh_token&refresh_token=" . refresh, arg, true)
-		MsgBox, % "Spoofy responds to refresh with:`n" . response
 		this.authState := true
 		if (InStr(response, "refresh_token")) {
 			this.SaveRefreshToken(response)
@@ -71,7 +62,6 @@ class Util {
 		this.SetTimeout()
 	}
 	FetchTokens() {
-		MsgBox, % "FetchTokens called"
 		if (this.fail) {
 			ErrorLevel := 1
 			return
@@ -82,7 +72,6 @@ class Util {
 		AHKsock_Close(-1)
 		arg := {1:{1:"Content-Type", 2:"application/x-www-form-urlencoded"}, 2:{1:"Authorization", 2:"Basic OWZlMjYyOTZiYjdiNDMzMGFjNTkzMzllZmQyNzQyYjA6ZWNhNjU2ZDFkNTczNDNhOTllMWJjNWVmODQ0YmY2NGM="}}
 		response := this.CustomCall("POST", "https://accounts.spotify.com/api/token?grant_type=authorization_code&code=" . this.auth . "&redirect_uri=http:%2F%2Flocalhost:8000%2Fcallback", arg, true)
-		MsgBox, % "Spoofy responds with:`n" . response
 		RegexMatch(response, "s_token"":"".*?""", token)
 		this.token := this.TrimToken(token)
 		this.SaveRefreshToken(response)
@@ -97,7 +86,7 @@ class Util {
 		return
 	}
 	TrimToken(token) {
-		return (SubStr(token, 11, (StrLen(token) - 12)))
+		return SubStr(token, 13, (StrLen(token) - 1))
 	}
 	CustomCall(method, url, HeaderArray := "", noTimeOut := false) {
 		if !(noTimeOut) {

--- a/Spotify.ahk
+++ b/Spotify.ahk
@@ -9,7 +9,7 @@ class Spotify {
 	}
 }
 class Util {
-	__New(ParentObject) {
+	__New(ByRef ParentObject) {
 		this.ParentObject := ParentObject
 		this.RefreshLoc := "HKCU\Software\SpotifyAHK"
 		this.StartUp()
@@ -159,7 +159,7 @@ class Util {
 	}
 }
 class Player {
-	__New(ParentObject) {
+	__New(ByRef ParentObject) {
 		this.ParentObject := ParentObject
 	}
 	SetVolume(volume) {
@@ -203,7 +203,7 @@ class Player {
 	}	
 }
 class Library {
-	__New(ParentObject) {
+	__New(ByRef ParentObject) {
 		this.ParentObject := ParentObject
 	}
 	CheckSavedForAlbum(AlbumID) {
@@ -232,7 +232,7 @@ class Library {
 	}
 }
 class Albums {
-	__New(ParentObject) {
+	__New(ByRef ParentObject) {
 		this.ParentObject := ParentObject
 	}
 	GetAlbum(AlbumID) {
@@ -243,7 +243,7 @@ class Albums {
 	}
 }
 class Artists {
-	__New(ParentObject) {
+	__New(ByRef ParentObject) {
 		this.ParentObject := ParentObject
 	}
 	GetArtist(ArtistID) {
@@ -260,7 +260,7 @@ class Artists {
 	}
 }
 class Tracks {
-	__New(ParentObject) {
+	__New(ByRef ParentObject) {
 		this.ParentObject := ParentObject
 	}
 	GetAudioFeatures(TrackID) {

--- a/Spotify.ahk
+++ b/Spotify.ahk
@@ -34,6 +34,9 @@ class Util {
 			this.FetchTokens()
 		}
 	}
+	
+	; Timeout methods
+	
 	SetTimeout() {
 		TimeOut := A_Now
 		EnvAdd, TimeOut, 1, hours
@@ -49,6 +52,9 @@ class Util {
 			this.RefreshTempToken(refresh)
 		}
 	}
+	
+	; API token operations
+	
 	RefreshTempToken(refresh) {
 		refresh := this.DecryptToken(refresh)
 		arg := {1:{1:"Content-Type", 2:"application/x-www-form-urlencoded"}, 2:{1:"Authorization", 2:"Basic OWZlMjYyOTZiYjdiNDMzMGFjNTkzMzllZmQyNzQyYjA6ZWNhNjU2ZDFkNTczNDNhOTllMWJjNWVmODQ0YmY2NGM="}}
@@ -76,6 +82,9 @@ class Util {
 		this.token := this.TrimToken(token)
 		this.SaveRefreshToken(response)
 	}
+	
+	; Local token operations
+	
 	SaveRefreshToken(response) {
 		RegexMatch(response, "h_token"":"".*?""", response)
 		if !(response) {
@@ -88,6 +97,9 @@ class Util {
 	TrimToken(token) {
 		return SubStr(token, 13, (StrLen(token) - 1))
 	}
+	
+	; API call method with auto-auth/timeout check/base URL
+	
 	CustomCall(method, url, HeaderArray := "", noTimeOut := false) {
 		if !(noTimeOut) {
 			this.CheckTimeout()
@@ -106,6 +118,9 @@ class Util {
 		SpotifyWinHttp.Send()
 		return SpotifyWinHttp.ResponseText
 	}
+	
+	; Web auth methods
+	
 	NotFound(ByRef req, ByRef res) {
 		res.SetBodyText("Page not found")
 	}
@@ -118,6 +133,9 @@ class Util {
 	WebAuthDone() {
 		return (this.auth ? true : false)
 	}
+	
+	; Token encryption/decryption methods
+	
 	EncryptToken(RefreshToken) {
 		return crypt.encrypt.strEncrypt(RefreshToken, this.GetIDs(), 5, 3)
 	}
@@ -131,18 +149,18 @@ class Util {
 			return crypt.encrypt.strDecrypt(RefreshToken, this.GetIDs(), 5, 3)
 		}
 	}
-	GetIDs(){
+	GetIDs() {
 		static infos := [["ProcessorID", "Win32_Service"], ["SKU", "Win32_BaseBoard"], ["DeviceID", "Win32_USBController"]]
 		wmi := ComObjGet("winmgmts:")
 		id := ""
 		for i, a in infos {
-			wmin:=wmi.execQuery("Select " . a[1] . " from " . a[2])._newEnum
-			while wmin[wminf]
+			wmin := wmi.execQuery("Select " . a[1] . " from " . a[2])._newEnum
+			while wmin[wminf] {
 				id .= wminf[a[1]]
+			}
 		}
 		return id
 	}
-	
 }
 class Player {
 	__New(ParentObject) {

--- a/Spotify.ahk
+++ b/Spotify.ahk
@@ -18,8 +18,7 @@ class Util {
 		RegRead, refresh, % this.RefreshLoc, refreshToken
 		if (refresh) {
 			this.RefreshTempToken(refresh)
-		}
-		else {
+		} else {
 			this.auth := ""
 			paths := {}
 			paths["/callback"] := this["authCallback"].bind(this)
@@ -63,8 +62,8 @@ class Util {
 		if (InStr(response, "refresh_token")) {
 			this.SaveRefreshToken(response)
 		}
-		RegexMatch(response, "s_token"":"".*?""", token)
-		this.token := this.TrimToken(token)
+		RegexMatch(response, "access_token"":""\K.*?(?="")", token)
+		this.token := token
 		this.SetTimeout()
 	}
 	FetchTokens() {
@@ -78,24 +77,21 @@ class Util {
 		AHKsock_Close(-1)
 		arg := {1:{1:"Content-Type", 2:"application/x-www-form-urlencoded"}, 2:{1:"Authorization", 2:"Basic OWZlMjYyOTZiYjdiNDMzMGFjNTkzMzllZmQyNzQyYjA6ZWNhNjU2ZDFkNTczNDNhOTllMWJjNWVmODQ0YmY2NGM="}}
 		response := this.CustomCall("POST", "https://accounts.spotify.com/api/token?grant_type=authorization_code&code=" . this.auth . "&redirect_uri=http:%2F%2Flocalhost:8000%2Fcallback", arg, true)
-		RegexMatch(response, "s_token"":"".*?""", token)
-		this.token := this.TrimToken(token)
+		RegexMatch(response, "access_token"":""\K.*?(?="")", token)
+		this.token := token
 		this.SaveRefreshToken(response)
 	}
 	
 	; Local token operations
 	
 	SaveRefreshToken(response) {
-		RegexMatch(response, "h_token"":"".*?""", response)
+		RegexMatch(response, "refresh_token"":""\K.*?(?="")", response)
 		if !(response) {
 			return
 		}
-		response := this.encryptToken(this.TrimToken(response))
+		response := this.encryptToken(response)
 		RegWrite, REG_SZ, % this.RefreshLoc, RefreshToken, % response
 		return
-	}
-	TrimToken(token) {
-		return SubStr(token, 13, (StrLen(token) - 1))
 	}
 	
 	; API call method with auto-auth/timeout check/base URL


### PR DESCRIPTION
Dev is finally working, and has some good optimization done. Artist objects were removed until I figure out a good way to handle Spotify's custom objects. A new way to parse values out of response text was implemented, making `TrimToken()` obsolete (it has been removed). Various methods have been renamed to better explain what they do, headers for related methods have also been added. A new parameter can be/is  passed to `CustomCall()` that will prevent accidental recursion during startup. Ready methods have been removed and replaced with `WebAuthDone()` which will return true if the time-sensitive portion of Spotify.ahk has been executed and it is safe to use `Sleep`.